### PR TITLE
added swagger api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
-# Ref Card 03
+# Ref Card 03 - Joke API
 
-A minimalistic Spring Boot Application that depends on a database.
+Eine minimalistische Spring Boot Anwendung mit Datenbankanbindung für Witze und Humor.
 
-Building it with Gradle will put a fat-jar under `build/libs/*.jar`
+## 🚀 Schnellstart
+
+### Build
+
+Mit Gradle wird eine fat-jar unter `build/libs/*.jar` erstellt:
+
 ```bash
 ./gradlew assemble
 ```
 
-The application will start on port 8080.
+### Start
+
+Die Anwendung startet auf Port 8080:
+
+```bash
+./gradlew bootRun
+```
+
+## 📚 API Dokumentation
+
+Die API ist vollständig mit OpenAPI/Swagger dokumentiert:
+
+- **Swagger UI**: http://localhost:8080/swagger-ui.html
+- **OpenAPI JSON**: http://localhost:8080/api-docs
+
+### Verfügbare Endpoints
+
+- `GET /api/jokes` - Alle Witze abrufen
+- `GET /swagger-ui.html` - Interaktive API Dokumentation
+- `GET /api-docs` - OpenAPI Spezifikation (JSON)
+
+## 🛠️ Technologie Stack
+
+- **Spring Boot 3.4.5**
+- **Spring Data JPA**
+- **MariaDB**
+- **OpenAPI/Swagger**
+- **Lombok**
+- **Java 21**

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	
+	// OpenAPI/Swagger documentation
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 

--- a/src/main/java/ch/bbw/m347/refcard03/config/OpenApiConfig.java
+++ b/src/main/java/ch/bbw/m347/refcard03/config/OpenApiConfig.java
@@ -1,0 +1,39 @@
+package ch.bbw.m347.refcard03.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Joke API")
+                        .description("Eine Spring Boot API für Witze und Humor")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("BBW M347 Team")
+                                .email("info@bbw.ch")
+                                .url("https://www.bbw.ch"))
+                        .license(new License()
+                                .name("MIT License")
+                                .url("https://opensource.org/licenses/MIT")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("Development Server"),
+                        new Server()
+                                .url("https://api.jokes.com")
+                                .description("Production Server")
+                ));
+    }
+} 

--- a/src/main/java/ch/bbw/m347/refcard03/controller/JokeController.java
+++ b/src/main/java/ch/bbw/m347/refcard03/controller/JokeController.java
@@ -4,7 +4,14 @@ import java.util.List;
 
 import ch.bbw.m347.refcard03.repository.JokeRepository;
 import ch.bbw.m347.refcard03.datamodel.JokeEntity;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,12 +19,32 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api")
 @RequiredArgsConstructor
+@Tag(name = "Jokes", description = "API für Witze und Humor")
 public class JokeController {
 
 	private final JokeRepository jokeRepository;
 
 	@GetMapping("jokes")
-	public List<JokeEntity> allJokes() {
-		return jokeRepository.findAll();
+	@Operation(
+		summary = "Alle Witze abrufen",
+		description = "Gibt eine Liste aller verfügbaren Witze zurück"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "Erfolgreich alle Witze abgerufen",
+			content = @Content(
+				mediaType = "application/json",
+				schema = @Schema(implementation = JokeEntity.class)
+			)
+		),
+		@ApiResponse(
+			responseCode = "500",
+			description = "Interner Server Fehler"
+		)
+	})
+	public ResponseEntity<List<JokeEntity>> allJokes() {
+		List<JokeEntity> jokes = jokeRepository.findAll();
+		return ResponseEntity.ok(jokes);
 	}
 }

--- a/src/main/java/ch/bbw/m347/refcard03/datamodel/JokeEntity.java
+++ b/src/main/java/ch/bbw/m347/refcard03/datamodel/JokeEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -24,22 +25,28 @@ import org.springframework.data.annotation.CreatedDate;
 @Entity
 @Table(name = "joke")
 @EntityListeners(AuditListener.class)
+@Schema(description = "Ein Witz mit Text, Bewertung und Kategorie")
 public class JokeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
+	@Schema(description = "Eindeutige ID des Witzes", example = "123e4567-e89b-12d3-a456-426614174000")
 	private UUID id;
 
+	@Schema(description = "Der Text des Witzes", example = "Warum können Skelette schlecht lügen? Weil sie so leicht zu durchschauen sind!")
 	private String text;
 
+	@Schema(description = "Bewertung des Witzes (1-10)", example = "8", minimum = "1", maximum = "10")
 	private int rating;
 
 	@CreatedDate
+	@Schema(description = "Erstellungsdatum des Witzes", example = "2024-01-15T10:30:00")
 	private LocalDateTime creationDate;
 
 	@ManyToOne
 	@JoinColumn(name = "section_idfs", nullable = false)
 	@JsonIgnore
+	@Schema(description = "Kategorie des Witzes")
 	private SectionEntity section;
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,19 @@ spring:
   jackson:
     serialization:
       indent-output: true
+
+# OpenAPI/Swagger Configuration
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    doc-expansion: none
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json
+
 logging:
   pattern:
     console: "%clr(%5p) %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:%wEx}"


### PR DESCRIPTION
##  Merge Request: API-Dokumentation mit OpenAPI/Swagger hinzufügen

###  Beschreibung
Diese MR fügt eine vollständige OpenAPI/Swagger Dokumentation zur Joke API hinzu, um die Entwicklerfreundlichkeit und API-Nutzbarkeit zu verbessern.

### ✨ Neue Features
- **Swagger UI Integration**: Interaktive API-Dokumentation unter `/swagger-ui.html`
- **OpenAPI Spezifikation**: Maschinenlesbare API-Docs unter `/api-docs`
- **Verbesserte Controller-Dokumentation**: Detaillierte Annotations für alle Endpoints
- **Entity-Dokumentation**: Schema-Beschreibungen mit Beispielen und Validierungsregeln
- **Erweiterte README**: Vollständige Dokumentation der neuen Features

### 🛠️ Technische Änderungen

#### Dependencies
- `springdoc-openapi-starter-webmvc-ui:2.5.0` hinzugefügt

#### Neue Dateien
- `src/main/java/ch/bbw/m347/refcard03/config/OpenApiConfig.java` - OpenAPI Konfiguration

#### Geänderte Dateien
- `build.gradle` - OpenAPI Dependency hinzugefügt
- `JokeController.java` - Swagger Annotations und bessere Response-Handling
- `JokeEntity.java` - Schema-Dokumentation für alle Felder
- `application.yaml` - OpenAPI Konfiguration
- `README.md` - Vollständige Dokumentation erweitert
